### PR TITLE
Update anti_spoof_predict.py

### DIFF
--- a/src/anti_spoof_predict.py
+++ b/src/anti_spoof_predict.py
@@ -30,7 +30,7 @@ class Detection:
         caffemodel = "./resources/detection_model/Widerface-RetinaFace.caffemodel"
         deploy = "./resources/detection_model/deploy.prototxt"
         self.detector = cv2.dnn.readNetFromCaffe(deploy, caffemodel)
-        self.detector_confidence = 0.6
+        # self.detector_confidence = 0.6
 
     def get_bbox(self, img):
         height, width = img.shape[0], img.shape[1]


### PR DESCRIPTION
Hello, I Do not see the use of this detector_confidence variable. Changing it also has no effect since its not used.
I would also like to mention that i have been getting bboxes with [0 0 1 1] coordinates, which to my understanding shows that the model failed to detect a face and the anti spoofing model was ran on the whole image, I d like to see if you can help me with a solution for that.